### PR TITLE
Fix: readded support for 1.4 (fixed toolchain usage)

### DIFF
--- a/Source/Utilities.cs
+++ b/Source/Utilities.cs
@@ -37,7 +37,7 @@ namespace PerfectPlacement
             public bool? IsReinstall;
             public bool? IsRotatable;
         }
-        private static readonly ConditionalWeakTable<Designator, CacheData> InstanceCache = new ConditionalWeakTable<Designator, CacheData>();
+        private static ConditionalWeakTable<Designator, CacheData> InstanceCache = new ConditionalWeakTable<Designator, CacheData>();
 
         [ThreadStatic]
         private static bool _suppressMouseCellPin;
@@ -309,7 +309,9 @@ namespace PerfectPlacement
         public static void ClearRotatableCache()
         {
             RotatableDesignatorCache.Clear();
-            InstanceCache.Clear();
+            // ConditionalWeakTable.Clear is not available on older frameworks (e.g., 1.4 toolchain).
+            // Reinitialize the table to effectively clear cached entries across all target versions.
+            InstanceCache = new ConditionalWeakTable<Designator, CacheData>();
         }
 
         public static void ClearTransientAll()


### PR DESCRIPTION
This pull request updates the cache-clearing logic in `Source/Utilities.cs` to improve compatibility with older .NET frameworks that do not support `ConditionalWeakTable.Clear()`. The main change is to reinitialize the cache instead of calling `Clear()`, ensuring cache entries are properly cleared across all target versions.

**Cache management improvements:**

* Changed `InstanceCache` from `readonly` to a mutable static field to allow reinitialization when clearing the cache.
* Updated `ClearRotatableCache()` to reinitialize `InstanceCache` instead of calling `Clear()`, ensuring compatibility with older frameworks lacking `ConditionalWeakTable.Clear()`.