### PR TITLE
Improvement: Refactor rotation handling to focus on DesignatorManager patches

### DIFF
--- a/Source/HarmonyPatches.cs
+++ b/Source/HarmonyPatches.cs
@@ -83,89 +83,6 @@ namespace PerfectPlacement
         }
     }
 
-    [HarmonyPatch]
-    public static class Patch_Designator_DesignateSingleCell_MouseRotate_All
-    {
-        static IEnumerable<MethodBase> TargetMethods()
-        {
-            var targets = new[] { typeof(Designator_Install), typeof(Designator_Place), typeof(Designator_Build) };
-            foreach (var t in targets)
-            {
-                var m = FindDesignateSingleCell(t);
-                if (m != null) yield return m;
-            }
-        }
-
-        private static MethodInfo FindDesignateSingleCell(Type t)
-        {
-            var intVec3 = typeof(IntVec3);
-            var direct = AccessTools.Method(t, "DesignateSingleCell", new[] { intVec3 });
-            if (direct != null) return direct;
-
-            foreach (var mi in AccessTools.GetDeclaredMethods(t))
-            {
-                if (!mi.Name.Contains("Designate")) continue;
-                var pars = mi.GetParameters();
-                if (pars.Length == 1 && pars[0].ParameterType == intVec3 && mi.ReturnType == typeof(void))
-                {
-                    return mi;
-                }
-            }
-
-            var bt = t.BaseType;
-            while (bt != null)
-            {
-                var m = AccessTools.Method(bt, "DesignateSingleCell", new[] { intVec3 });
-                if (m != null) return m;
-
-                foreach (var mi in AccessTools.GetDeclaredMethods(bt))
-                {
-                    if (!mi.Name.Contains("Designate")) continue;
-                    var pars = mi.GetParameters();
-                    if (pars.Length == 1 && pars[0].ParameterType == intVec3 && mi.ReturnType == typeof(void))
-                    {
-                        return mi;
-                    }
-                }
-                bt = bt.BaseType;
-            }
-            return null;
-        }
-
-        static bool Prepare() => TargetMethods().Any();
-
-        public static bool Prefix(Designator __instance)
-        {
-            return Utilities.HandleDesignatePrefix(__instance);
-        }
-    }
-
-    [HarmonyPatch(typeof(UI), nameof(UI.MouseCell))]
-    public static class Patch_UI_MouseCell_PinDuringRotate
-    {
-        public static bool Prefix(ref IntVec3 __result)
-        {
-            var settings = PerfectPlacement.Settings;
-            if (settings == null) return true;
-            if (Utilities.SuppressMouseCellPin) return true;
-            if (!Utilities.HasAnyPinned) return true;
-            try
-            {
-                var des = Utilities.CurrentSelectedDesignator();
-                if (!(des is Designator_Install) && !(des is Designator_Place) && !(des is Designator_Build)) return true;
-                bool mouseRotateEnabled = Utilities.MouseRotateEnabledFor(des, settings);
-                if (!mouseRotateEnabled || !Utilities.IsRotatable(des)) return true;
-                if (Utilities.TryGetPinned(des, out var pin))
-                {
-                    __result = pin;
-                    return false;
-                }
-            }
-            catch { }
-            return true;
-        }
-    }
-
     [HarmonyPatch(typeof(DesignatorManager), nameof(DesignatorManager.Select))]
     public static class Patch_DesignatorManager_Select
     {
@@ -178,210 +95,59 @@ namespace PerfectPlacement
         }
     }
 
-    [HarmonyPatch(typeof(Designator_Install), nameof(Designator_Install.SelectedUpdate))]
-    public static class Patch_Designator_Install_SelectedUpdate
-    {
-        public static void Prefix(Designator __instance)
-        {
-            if (__instance == null) return;
-            Utilities.ConsumeLeftClickIfMouseRotate(__instance);
-        }
-
-        public static void Postfix(Designator __instance)
-        {
-            if (__instance == null) return;
-            try
-            {
-                var settings = PerfectPlacement.Settings;
-                if (settings == null) return;
-
-                bool isReinstall = Utilities.IsReinstallDesignator(__instance, out var source);
-
-                bool anyActive = isReinstall
-                    ? (settings.useOverrideRotation || settings.PerfectPlacement)
-                    : (settings.installOverrideRotation != Rot4.South);
-                if (!anyActive) return;
-
-                if (Utilities.ApplyInstallOrReinstallOverrideIfNeeded(__instance, settings, isReinstall)) return;
-
-                if (isReinstall && settings.PerfectPlacement && !Utilities.WasApplied(__instance))
-                {
-                    if (Utilities.IsRotatable(__instance))
-                    {
-                        var desiredKeep = source.Rotation;
-                        if (Utilities.SetAllPlacingRotFields(__instance, desiredKeep)) Utilities.MarkApplied(__instance);
-                        else Utilities.DebugLog(() => $"KeepRotation: failed to set placingRot for {__instance.GetType().Name}");
-                    }
-                    else
-                    {
-                        Utilities.DebugLog(() => $"KeepRotation: not rotatable or null source. src={(source==null?"<null>":source.def.defName)}");
-                    }
-                }
-                if (Utilities.HandleMouseRotate(__instance)) return;
-            }
-            catch (Exception e)
-            {
-                Log.Warning("[PerfectPlacement] Install.SelectedUpdate failed: " + e.Message);
-            }
-        }
-    }
-
-    
-
-    [HarmonyPatch(typeof(Designator_Place), nameof(Designator_Place.SelectedUpdate))]
-    public static class Patch_Designator_Place_SelectedUpdate
-    {
-        public static void Prefix(Designator __instance)
-        {
-            if (__instance == null) return;
-            Utilities.ConsumeLeftClickIfMouseRotate(__instance);
-        }
-        public static void Postfix(Designator __instance)
-        {
-            if (__instance == null) return;
-            try
-            {
-                var settings = PerfectPlacement.Settings;
-                if (settings == null) return;
-
-                bool buildActive = (__instance is Designator_Build) && (settings.buildOverrideRotation != Rot4.South);
-                bool anyActive = buildActive || Utilities.MouseRotateEnabledFor(__instance, settings);
-                if (!anyActive) return;
-
-                if (__instance is Designator_Build)
-                {
-                    Utilities.ApplyBuildOverrideIfNeeded(__instance, settings);
-                }
-                if (Utilities.HandleMouseRotate(__instance)) return;
-            }
-            catch (Exception e)
-            {
-                Log.Warning("[PerfectPlacement] Place.SelectedUpdate failed: " + e.Message);
-            }
-        }
-    }
-
-    
-
-    [HarmonyPatch(typeof(Designator_Build), nameof(Designator_Build.SelectedUpdate))]
-    public static class Patch_Designator_Build_SelectedUpdate
-    {
-        public static void Prefix(Designator __instance)
-        {
-            if (__instance == null) return;
-            Utilities.ConsumeLeftClickIfMouseRotate(__instance);
-        }
-        public static void Postfix(Designator __instance)
-        {
-            if (__instance == null) return;
-            try
-            {
-                var settings = PerfectPlacement.Settings;
-                if (settings == null) return;
-
-                bool anyActive = (settings.buildOverrideRotation != Rot4.South) || Utilities.MouseRotateEnabledFor(__instance, settings);
-                if (!anyActive) return;
-
-                Utilities.ApplyBuildOverrideIfNeeded(__instance, settings);
-                if (Utilities.HandleMouseRotate(__instance)) return;
-            }
-            catch (Exception e)
-            {
-                Log.Warning("[PerfectPlacement] Build.SelectedUpdate failed: " + e.Message);
-            }
-        }
-    }
-
-    
-
-    [HarmonyPatch]
-    public static class Patch_Designator_ProcessInput_MouseRotate
-    {
-        private static MethodBase _cachedTarget;
-        private static bool _isCached;
-
-        static MethodBase TargetMethod()
-        {
-            if (_isCached) return _cachedTarget;
-
-            _isCached = true;
-            var t = typeof(Designator);
-            var m = AccessTools.Method(t, "ProcessInput", new[] { typeof(Event) });
-            if (m != null)
-            {
-                _cachedTarget = m;
-                return _cachedTarget;
-            }
-            foreach (var mi in AccessTools.GetDeclaredMethods(t))
-            {
-                if (mi.Name != "ProcessInput") continue;
-                var pars = mi.GetParameters();
-                if (pars.Length == 1 && pars[0].ParameterType == typeof(Event) && mi.ReturnType == typeof(void))
-                {
-                    _cachedTarget = mi;
-                    return _cachedTarget;
-                }
-            }
-            var bt = t.BaseType;
-            while (bt != null)
-            {
-                m = AccessTools.Method(bt, "ProcessInput", new[] { typeof(Event) });
-                if (m != null)
-                {
-                    _cachedTarget = m;
-                    return _cachedTarget;
-                }
-                foreach (var mi in AccessTools.GetDeclaredMethods(bt))
-                {
-                    if (mi.Name != "ProcessInput") continue;
-                    var pars = mi.GetParameters();
-                    if (pars.Length == 1 && pars[0].ParameterType == typeof(Event) && mi.ReturnType == typeof(void))
-                    {
-                        _cachedTarget = mi;
-                        return _cachedTarget;
-                    }
-                }
-                bt = bt.BaseType;
-            }
-            return null;
-        }
-
-        static bool Prepare() => TargetMethod() != null;
-
-        public static bool Prefix(Designator __instance, Event ev)
-        {
-            return Utilities.HandleProcessInputPrefix(__instance, ev);
-        }
-    }
-
     [HarmonyPatch(typeof(DesignatorManager), nameof(DesignatorManager.ProcessInputEvents))]
-    public static class Patch_DesignatorManager_ProcessInputEvents_SuppressWhilePinned
+    public static class Patch_DesignatorManager_ProcessInputEvents_MouseRotate
     {
-        public static bool Prefix()
+        public static bool Prefix(DesignatorManager __instance)
         {
             try
             {
-                var evt = Event.current;
-                var des = Utilities.CurrentSelectedDesignator();
-                var settings = PerfectPlacement.Settings;
-
-                Utilities.SetSuppressRejectsThisEvent(false);
-
-                if (evt != null && evt.type == EventType.MouseDown && evt.button == 0 && des != null && settings != null)
+                if (Utilities.HandleProcessInputEvents(__instance))
                 {
-                    if (Utilities.MouseRotateEnabledFor(des, settings) && Utilities.IsRotatable(des))
-                    {
-                        Utilities.SetSuppressRejectsThisEvent(true);
-                    }
+                    return false;
                 }
+            }
+            catch (Exception e)
+            {
+                Log.Warning("[PerfectPlacement] ProcessInputEvents prefix failed: " + e.Message);
+            }
+            return true;
+        }
+    }
 
-                if (Utilities.HasAnyPinned && des != null && settings != null)
+    [HarmonyPatch(typeof(DesignatorManager), nameof(DesignatorManager.DesignatorManagerUpdate))]
+    public static class Patch_DesignatorManager_DesignatorManagerUpdate_MouseRotate
+    {
+        public static void Postfix(DesignatorManager __instance)
+        {
+            try
+            {
+                Utilities.HandleDesignatorUpdate(__instance?.SelectedDesignator);
+            }
+            catch (Exception e)
+            {
+                Log.Warning("[PerfectPlacement] DesignatorManagerUpdate postfix failed: " + e.Message);
+            }
+        }
+    }
+    [HarmonyPatch(typeof(UI), nameof(UI.MouseCell))]
+    public static class Patch_UI_MouseCell_PinDuringRotate
+    {
+        public static bool Prefix(ref IntVec3 __result)
+        {
+            var settings = PerfectPlacement.Settings;
+            if (settings == null) return true;
+            if (Utilities.SuppressMouseCellPin) return true;
+            if (!Utilities.HasAnyPinned) return true;
+            try
+            {
+                var des = Find.DesignatorManager?.SelectedDesignator ?? Utilities.CurrentSelectedDesignator();
+                if (des == null) return true;
+                if (!Utilities.MouseRotateEnabledFor(des, settings) || !Utilities.IsRotatable(des)) return true;
+                if (Utilities.TryGetPinned(des, out var pin))
                 {
-                    if (Utilities.MouseRotateEnabledFor(des, settings) && evt != null && evt.type == EventType.MouseDown && evt.button == 0)
-                    {
-                        evt.Use();
-                        return false;
-                    }
+                    __result = pin;
+                    return false;
                 }
             }
             catch { }
@@ -389,57 +155,5 @@ namespace PerfectPlacement
         }
     }
 
-    [HarmonyPatch(typeof(Messages))]
-    public static class Patch_Messages_Message_Suppress_All
-    {
-        static IEnumerable<MethodBase> TargetMethods()
-        {
-            // Dynamically target all Messages.Message overloads (public/non-public, static)
-            return typeof(Messages)
-                .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
-                .Where(mi => mi.Name == nameof(Messages.Message));
-        }
 
-        static bool Prepare() => TargetMethods().Any();
-
-        public static bool Prefix(object[] __args)
-        {
-            try
-            {
-                if (__args == null || __args.Length == 0) return true;
-
-                MessageTypeDef def = null;
-                TaggedString text = default;
-                bool haveText = false;
-
-                foreach (var arg in __args)
-                {
-                    if (!haveText)
-                    {
-                        if (arg is string s)
-                        {
-                            text = s;
-                            haveText = true;
-                            continue;
-                        }
-                        if (arg is TaggedString ts)
-                        {
-                            text = ts;
-                            haveText = true;
-                            continue;
-                        }
-                    }
-                    if (def == null && arg is MessageTypeDef md)
-                    {
-                        def = md;
-                    }
-                }
-
-                if (!haveText || def == null) return true;
-                if (Utilities.ShouldSuppressDesignatorReject(text, def)) return false;
-            }
-            catch { }
-            return true;
-        }
-    }
 }


### PR DESCRIPTION
This pull request refactors and simplifies how mouse rotation and cell pinning are handled for designators, consolidating previously scattered logic and removing several redundant patches and state-tracking mechanisms. The changes streamline the patching strategy by shifting from multiple designator-specific patches to more centralized handling via `DesignatorManager`, and eliminate unused or unnecessary code related to placement arming and event/message suppression.

**Refactoring and Consolidation of Mouse Rotate Logic:**

* Replaced multiple designator-specific Harmony patches (for `Designator_Install`, `Designator_Place`, `Designator_Build`, and their `SelectedUpdate` methods) with centralized patches on `DesignatorManager.ProcessInputEvents` and `DesignatorManager.DesignatorManagerUpdate`, moving mouse rotate handling into these manager-level hooks. (`Source/HarmonyPatches.cs`, [Source/HarmonyPatches.csL181-L444](diffhunk://#diff-9789f11f2ca0b52689c176545aff7b50597b5673d179dc3a03e91ce39eeeac87L181-L444))
* Removed the complex patch targeting all `DesignateSingleCell` methods and the associated logic for arming and consuming placement actions, simplifying the flow for cell designation and rotation. (`Source/HarmonyPatches.cs`, [[1]](diffhunk://#diff-9789f11f2ca0b52689c176545aff7b50597b5673d179dc3a03e91ce39eeeac87L86-L168); `Source/Utilities.cs`, [[2]](diffhunk://#diff-6eff80efab82e471e4257081a00d5a75383840b39bd20c6a1dc5616b1df4bb41L323-L340) [[3]](diffhunk://#diff-6eff80efab82e471e4257081a00d5a75383840b39bd20c6a1dc5616b1df4bb41L879) [[4]](diffhunk://#diff-6eff80efab82e471e4257081a00d5a75383840b39bd20c6a1dc5616b1df4bb41L910-L933)

**Simplification and Cleanup:**

* Eliminated the `PlacementArmed` state and related methods (`ArmPlacement`, `TryConsumePlacementArmed`), as well as the suppression of mouse attachment overlays and message rejection events, reducing unnecessary state-tracking and complexity. (`Source/Utilities.cs`, [[1]](diffhunk://#diff-6eff80efab82e471e4257081a00d5a75383840b39bd20c6a1dc5616b1df4bb41L21-L22) [[2]](diffhunk://#diff-6eff80efab82e471e4257081a00d5a75383840b39bd20c6a1dc5616b1df4bb41L44-L45) [[3]](diffhunk://#diff-6eff80efab82e471e4257081a00d5a75383840b39bd20c6a1dc5616b1df4bb41L85-L86) [[4]](diffhunk://#diff-6eff80efab82e471e4257081a00d5a75383840b39bd20c6a1dc5616b1df4bb41L323-L340) [[5]](diffhunk://#diff-6eff80efab82e471e4257081a00d5a75383840b39bd20c6a1dc5616b1df4bb41L910-L933)
* Removed patches and logic for suppressing message popups during designator rejection, as well as event suppression during placement, further streamlining the codebase. (`Source/HarmonyPatches.cs`, [Source/HarmonyPatches.csL181-L444](diffhunk://#diff-9789f11f2ca0b52689c176545aff7b50597b5673d179dc3a03e91ce39eeeac87L181-L444))

**Centralized Pinning Logic:**

* Unified the logic for pinning the mouse cell during rotation into a single patch on `UI.MouseCell`, improving maintainability and ensuring consistent behavior when a cell is pinned. (`Source/HarmonyPatches.cs`, [[1]](diffhunk://#diff-9789f11f2ca0b52689c176545aff7b50597b5673d179dc3a03e91ce39eeeac87L86-L168) [[2]](diffhunk://#diff-9789f11f2ca0b52689c176545aff7b50597b5673d179dc3a03e91ce39eeeac87L181-L444)

These changes should make the code easier to maintain and extend, while reducing the risk of subtle bugs from overlapping or redundant patches.