### PR TITLE
Fix: Prime reinstall designators with the source’s rotation on select ion so keep-original blueprints render at the correct orientation immediately.

### DIFF
--- a/Source/HarmonyPatches.cs
+++ b/Source/HarmonyPatches.cs
@@ -92,6 +92,23 @@ namespace PerfectPlacement
             Utilities.ClearPinned(des);
             Utilities.ClearRotatableCache();
             Utilities.ClearTransientAll();
+
+            try
+            {
+                var settings = PerfectPlacement.Settings;
+                if (settings?.PerfectPlacement == true && des != null && !settings.useOverrideRotation)
+                {
+                    if (Utilities.IsReinstallDesignator(des, out var source) && source != null && Utilities.IsRotatable(des))
+                    {
+                        var desired = source.Rotation;
+                        if (Utilities.SetAllPlacingRotFields(des, desired))
+                        {
+                            Utilities.MarkApplied(des);
+                        }
+                    }
+                }
+            }
+            catch { }
         }
     }
 


### PR DESCRIPTION
Previously when maintaining rotation during a reinstall the blueprint would render a single frame facing South.  This is now fixed.

---

This pull request adds new logic to the `Postfix` method in `Source/HarmonyPatches.cs` to enhance how rotation is handled for designators during placement. The changes ensure that, under certain configuration settings, the rotation of reinstalled objects is automatically set and marked as applied, improving user experience and consistency.

Rotation handling improvements:

* Added a conditional block that checks if the `PerfectPlacement` setting is enabled, the designator is not null, and override rotation is not used. If these conditions are met and the designator is a reinstall designator that is rotatable, it sets the rotation to match the source object's rotation and marks the designator as applied.
* Wrapped the new logic in a `try-catch` block to prevent errors from disrupting the placement process.