### PR TITLE
Feat: added handling for build copy, new option added for maintaining rotation or overriding

### DIFF
--- a/Languages/English/Keyed/PerfectPlacement.xml
+++ b/Languages/English/Keyed/PerfectPlacement.xml
@@ -25,7 +25,14 @@
   <PP.Section.Build>When Building from the Architect menu:</PP.Section.Build>
   <PP.Label.BuildDirection>Build Direction</PP.Label.BuildDirection>
 
+  <!-- Build copy section -->
+  <PP.Section.BuildCopy>When using Build Copy:</PP.Section.BuildCopy>
+  <PP.Option.BuildCopy.Keep>Keep copied rotation</PP.Option.BuildCopy.Keep>
+  <PP.Option.BuildCopy.Keep.Desc>Apply the copied object's current rotation to the blueprint.</PP.Option.BuildCopy.Keep.Desc>
+  <PP.Option.BuildCopy.Override>Override copy rotation</PP.Option.BuildCopy.Override>
+  <PP.Option.BuildCopy.Override.Desc>Force copied blueprints to use a specific rotation.</PP.Option.BuildCopy.Override.Desc>
   <!-- Shared labels -->
   <PP.Label.OverrideDirection>Override Direction</PP.Label.OverrideDirection>
 </LanguageData>
+
 

--- a/Source/HarmonyPatches.cs
+++ b/Source/HarmonyPatches.cs
@@ -96,6 +96,7 @@ namespace PerfectPlacement
             try
             {
                 var settings = PerfectPlacement.Settings;
+                Utilities.ApplyBuildCopyOnSelect(des, settings);
                 if (settings?.PerfectPlacement == true && des != null && !settings.useOverrideRotation)
                 {
                     if (Utilities.IsReinstallDesignator(des, out var source) && source != null && Utilities.IsRotatable(des))
@@ -173,4 +174,28 @@ namespace PerfectPlacement
     }
 
 
+    [HarmonyPatch(typeof(BuildCopyCommandUtility), nameof(BuildCopyCommandUtility.BuildCopyCommand))]
+    public static class Patch_BuildCopyCommandUtility_BuildCopyCommand
+    {
+        public static void Postfix(BuildableDef buildable, Command __result)
+        {
+            try
+            {
+                if (__result is Command_Action action)
+                {
+                    var original = action.action;
+                    action.action = () =>
+                    {
+                        try
+                        {
+                            Utilities.RegisterBuildCopyFromSelection(buildable);
+                        }
+                        catch { }
+                        original?.Invoke();
+                    };
+                }
+            }
+            catch { }
+        }
+    }
 }

--- a/Source/PerfectPlacement.cs
+++ b/Source/PerfectPlacement.cs
@@ -109,6 +109,31 @@ namespace PerfectPlacement
                 Find.WindowStack.Add(new FloatMenu(opts));
             }
 
+            list.GapLine();
+
+            // --- BUILD COPY ---
+            Text.Font = GameFont.Medium;
+            list.Label("PP.Section.BuildCopy".Translate());
+            Text.Font = GameFont.Small;
+            list.Gap(6f);
+
+            bool buildCopyKeep = Settings.buildCopyMode == BuildCopyRotationMode.KeepSource;
+            bool buildCopyOverride = Settings.buildCopyMode == BuildCopyRotationMode.Override;
+
+            if (list.RadioButton("PP.Option.BuildCopy.Keep".Translate(), buildCopyKeep, tooltip: "PP.Option.BuildCopy.Keep.Desc".Translate()))
+            {
+                Settings.buildCopyMode = BuildCopyRotationMode.KeepSource;
+            }
+
+            if (list.RadioButton("PP.Option.BuildCopy.Override".Translate(), buildCopyOverride, tooltip: "PP.Option.BuildCopy.Override.Desc".Translate()))
+            {
+                Settings.buildCopyMode = BuildCopyRotationMode.Override;
+            }
+
+            if (Settings.buildCopyMode == BuildCopyRotationMode.Override)
+            {
+                DrawRotationWidget(list, Settings.buildCopyOverrideRotation, newRot => Settings.buildCopyOverrideRotation = newRot);
+            }
             list.End();
         }
 
@@ -143,3 +168,4 @@ namespace PerfectPlacement
         }
     }
 }
+

--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -2,6 +2,12 @@ using Verse;
 
 namespace PerfectPlacement
 {
+    public enum BuildCopyRotationMode
+    {
+        KeepSource,
+        Override
+    }
+
     public class PerfectPlacementSettings : ModSettings
     {
         // Global
@@ -19,6 +25,10 @@ namespace PerfectPlacement
         // Build
         public Rot4 buildOverrideRotation = Rot4.South;
 
+        // Build Copy
+        public BuildCopyRotationMode buildCopyMode = BuildCopyRotationMode.KeepSource;
+        public Rot4 buildCopyOverrideRotation = Rot4.South;
+
         public override void ExposeData()
         {
             base.ExposeData();
@@ -32,6 +42,9 @@ namespace PerfectPlacement
             Scribe_Values.Look(ref installOverrideRotation, nameof(installOverrideRotation), Rot4.South);
 
             Scribe_Values.Look(ref buildOverrideRotation, nameof(buildOverrideRotation), Rot4.South);
+
+            Scribe_Values.Look(ref buildCopyMode, nameof(buildCopyMode), BuildCopyRotationMode.KeepSource);
+            Scribe_Values.Look(ref buildCopyOverrideRotation, nameof(buildCopyOverrideRotation), Rot4.South);
         }
     }
 }


### PR DESCRIPTION
Previously there was no handling for the "Build Copy" gizmo.  Now it is fully handled and integrated.

---

This pull request introduces a new "Build Copy" feature to the Perfect Placement mod, allowing users to control blueprint rotation when copying buildings. The main changes add user-facing options, persist new settings, and implement the logic for capturing and applying rotation from the source object or an override value.

**Build Copy feature and settings:**

* Added a "Build Copy" section to the mod settings UI, allowing users to choose between keeping the copied object's rotation or overriding it with a specific rotation. The UI updates dynamically based on the selected mode.
* Introduced new settings fields and an enum (`BuildCopyRotationMode`, `buildCopyMode`, `buildCopyOverrideRotation`) in `Settings.cs` to persist user preferences for build copy behavior. [[1]](diffhunk://#diff-9fb7e847a9847743c3b3b763db5ec07bb420783070740f36e6fb707689a3e43bR5-R10) [[2]](diffhunk://#diff-9fb7e847a9847743c3b3b763db5ec07bb420783070740f36e6fb707689a3e43bR28-R31) [[3]](diffhunk://#diff-9fb7e847a9847743c3b3b763db5ec07bb420783070740f36e6fb707689a3e43bR45-R47)

**Localization and user interface:**

* Added new translation keys and descriptions for the Build Copy options in the English language file to support the UI changes.

**Core logic and Harmony patches:**

* Implemented logic in `Utilities.cs` to register the source object's rotation when a build copy command is issued, and apply the chosen rotation mode when the user selects a designator. [[1]](diffhunk://#diff-6eff80efab82e471e4257081a00d5a75383840b39bd20c6a1dc5616b1df4bb41R34-R41) [[2]](diffhunk://#diff-6eff80efab82e471e4257081a00d5a75383840b39bd20c6a1dc5616b1df4bb41R89-R203)
* Added Harmony patches to hook into build copy command execution and designator selection, ensuring the Build Copy rotation logic is triggered at the correct times. [[1]](diffhunk://#diff-9789f11f2ca0b52689c176545aff7b50597b5673d179dc3a03e91ce39eeeac87R99) [[2]](diffhunk://#diff-9789f11f2ca0b52689c176545aff7b50597b5673d179dc3a03e91ce39eeeac87R177-R200)